### PR TITLE
Remove PyAlarm from dependencies

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -6,7 +6,6 @@ build_requires = python
 requires = python-fandango
            python-taurus
            python-pytango
-           tangods-pyalarm
            qtwebkit
 
 release = 1%{?dist}.maxlab

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 
 setup(
     name="python-svgsynoptic2",
-    version="3.1.3",
+    version="3.1.4",
     description="Widget for displaying a SVG synoptic.",
     author="Johan Forsberg",
     author_email="johan.forsberg@maxlab.lu.se",


### PR DESCRIPTION
This repo don't need PyAlarm as dependency.